### PR TITLE
Support adding arbitrary properties to the underlying anchor tag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       },
       "devDependencies": {
         "rimraf": "^3.0.2",
-        "typescript": "^4.3.5"
+        "typescript": "^4.5.4"
       }
     },
     "node_modules/balanced-match": {
@@ -131,9 +131,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -248,9 +248,9 @@
       }
     },
     "typescript": {
-      "version": "4.3.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
-      "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.5.4.tgz",
+      "integrity": "sha512-VgYs2A2QIRuGphtzFV7aQJduJ2gyfTljngLzjpfW9FoYZF6xuw1W0vW9ghCKLfcWrCFxK81CSGRAvS1pn4fIUg==",
       "dev": true
     },
     "wrappy": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "devDependencies": {
     "rimraf": "^3.0.2",
-    "typescript": "^4.3.5"
+    "typescript": "^4.5.4"
   },
   "scripts": {
     "clean": "rimraf ./dist",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,6 @@
 import * as forgo from "forgo";
 import { rerender, ForgoRenderArgs, ForgoNode, ForgoElementArg } from "forgo";
+import type { JSX } from "forgo";
 
 /*
   To be called when the url needs to be changed.
@@ -58,26 +59,22 @@ export function Router(props: RouterProps) {
   };
 }
 
-export type LinkProps = {
-  key?: any;
+export interface LinkProps
+  // We deny the onclick attribute because we set our own click handler and
+  // don't presently support merging click handlers
+  extends Omit<JSX.HTMLAttributes<HTMLAnchorElement>, "onclick"> {
+  // Override HTMLAnchorElement's href attribute to be mandatory
   href: string;
+  key?: any;
   children?: ForgoNode | ForgoNode[];
-  style?: any;
-  className?: string;
-};
+}
 
-export function Link(props: LinkProps) {
+export function Link(_props: LinkProps) {
   return {
-    render(props: LinkProps) {
+    render({ children, ...props }: LinkProps) {
       return (
-        <a
-          key={props.key}
-          style={props.style}
-          onclick={createClickHandler(props.href)}
-          href={props.href}
-          className={props.className}
-        >
-          {props.children}
+        <a {...props} onclick={createClickHandler(props.href)}>
+          {children}
         </a>
       );
     },


### PR DESCRIPTION
This PR updates the `Link` component to take all the same props as an `<a>` tag, which enables e.g., setting `data-cy` attributes to power Cypress tests.

I upgraded TypeScript because in my test setup using `npm link forgo-router`, `extends Omit<JSX.HTMLAttributes<HTMLAnchorElement>, "onclick">` swallowed all of the anchor attributes off of the `LinkProps` interface, even though `extends JSX.HTMLAttributes<HTMLAnchorElement>` worked. Upgrading to typescript@latest fixed that.