### PR TITLE
Update to new component API #3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forgo-router",
-  "version": "2.0.0-alpha.0",
+  "version": "1.3.0-beta.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "forgo-router",
-      "version": "2.0.0-alpha.0",
+      "version": "1.3.0-beta.0",
       "license": "MIT",
       "devDependencies": {
         "rimraf": "^3.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "typescript": "^4.6.3"
       },
       "peerDependencies": {
-        "forgo": "^3.1.0"
+        "forgo": "^4.0.0-alpha.0"
       }
     },
     "node_modules/balanced-match": {
@@ -39,9 +39,9 @@
       "dev": true
     },
     "node_modules/forgo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.1.0.tgz",
-      "integrity": "sha512-u5QZ9vnRJoIcZelwZ3kYzJ+jrbh+lvx1Ixp5+GXxE2I3/AVdgK5IeL1hGgi3rBfhlxKjcs2fqKPycOED8FT5SQ==",
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/forgo/-/forgo-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-D8H+ise8kS3vHWZBJRnlCIEBhC0GypT2cy+1Mf2eyuF6Jo4qxyAPw85cwdVQOosADP16UzEQjzATLb4depAiJg==",
       "peer": true
     },
     "node_modules/fs.realpath": {
@@ -175,9 +175,9 @@
       "dev": true
     },
     "forgo": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.1.0.tgz",
-      "integrity": "sha512-u5QZ9vnRJoIcZelwZ3kYzJ+jrbh+lvx1Ixp5+GXxE2I3/AVdgK5IeL1hGgi3rBfhlxKjcs2fqKPycOED8FT5SQ==",
+      "version": "4.0.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/forgo/-/forgo-4.0.0-alpha.0.tgz",
+      "integrity": "sha512-D8H+ise8kS3vHWZBJRnlCIEBhC0GypT2cy+1Mf2eyuF6Jo4qxyAPw85cwdVQOosADP16UzEQjzATLb4depAiJg==",
       "peer": true
     },
     "fs.realpath": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "typescript": "^4.6.3"
       },
       "peerDependencies": {
-        "forgo": "^4.0.0-alpha.0"
+        "forgo": "^3.2.0-beta.0"
       }
     },
     "node_modules/balanced-match": {
@@ -39,9 +39,9 @@
       "dev": true
     },
     "node_modules/forgo": {
-      "version": "4.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/forgo/-/forgo-4.0.0-alpha.0.tgz",
-      "integrity": "sha512-D8H+ise8kS3vHWZBJRnlCIEBhC0GypT2cy+1Mf2eyuF6Jo4qxyAPw85cwdVQOosADP16UzEQjzATLb4depAiJg==",
+      "version": "3.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.2.0-beta.0.tgz",
+      "integrity": "sha512-JSLvM3Xwa++R2Y09b9TIoPueITRoF0pLQuXTZWoTBZ/fBqVbrIxlaEOBF+q9YTQbE97Cxag0rC1CvWwcjevWoA==",
       "peer": true
     },
     "node_modules/fs.realpath": {
@@ -175,9 +175,9 @@
       "dev": true
     },
     "forgo": {
-      "version": "4.0.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/forgo/-/forgo-4.0.0-alpha.0.tgz",
-      "integrity": "sha512-D8H+ise8kS3vHWZBJRnlCIEBhC0GypT2cy+1Mf2eyuF6Jo4qxyAPw85cwdVQOosADP16UzEQjzATLb4depAiJg==",
+      "version": "3.2.0-beta.0",
+      "resolved": "https://registry.npmjs.org/forgo/-/forgo-3.2.0-beta.0.tgz",
+      "integrity": "sha512-JSLvM3Xwa++R2Y09b9TIoPueITRoF0pLQuXTZWoTBZ/fBqVbrIxlaEOBF+q9YTQbE97Cxag0rC1CvWwcjevWoA==",
       "peer": true
     },
     "fs.realpath": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "forgo-router",
-  "version": "1.2.0",
+  "version": "2.0.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "forgo-router",
-      "version": "1.2.0",
+      "version": "2.0.0-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forgo-router",
-  "version": "1.2.0",
+  "version": "2.0.0-alpha.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "https://github.com/forgojs/forgo-router"
   },
   "peerDependencies": {
-    "forgo": "^3.1.0"
+    "forgo": "^4.0.0-alpha.0"
   },
   "devDependencies": {
     "rimraf": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forgo-router",
-  "version": "1.2.0",
+  "version": "1.3.0-beta.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "forgo-router",
-  "version": "2.0.0-alpha.0",
+  "version": "1.2.0",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -10,7 +10,7 @@
     "url": "https://github.com/forgojs/forgo-router"
   },
   "peerDependencies": {
-    "forgo": "^4.0.0-alpha.0"
+    "forgo": "^3.2.0-beta.0"
   },
   "devDependencies": {
     "rimraf": "^3.0.2",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,7 +2,7 @@ import * as forgo from "forgo";
 import { rerender, ForgoNode, Component } from "forgo";
 import type { JSX } from "forgo";
 
-import type { ForgoComponentCtor } from "forgo";
+import type { ForgoNewComponentCtor } from "forgo";
 
 /*
   To be called when the url needs to be changed.
@@ -42,7 +42,7 @@ export type RouterProps = {
 
 let component: Component;
 
-export const Router: ForgoComponentCtor<RouterProps> = (props) => {
+export const Router: ForgoNewComponentCtor<RouterProps> = (props) => {
   if (!props.skipHistoryEventRegistration) {
     window.addEventListener("popstate", () => {
       updateRoute();
@@ -71,7 +71,7 @@ export interface LinkProps
   children?: ForgoNode | ForgoNode[];
 }
 
-export const Link: ForgoComponentCtor<LinkProps> = () => {
+export const Link: ForgoNewComponentCtor<LinkProps> = () => {
   return new Component({
     render({ children, ...props }: LinkProps) {
       return (

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,8 @@
 import * as forgo from "forgo";
-import { rerender, ForgoRenderArgs, ForgoNode, ForgoElementArg } from "forgo";
+import { rerender, ForgoNode, Component } from "forgo";
 import type { JSX } from "forgo";
+
+import type { ForgoComponentCtor } from "forgo";
 
 /*
   To be called when the url needs to be changed.
@@ -27,8 +29,8 @@ export function goBack(steps = -1) {
 */
 export function updateRoute() {
   const elem = {
-    ...routerRenderArgs.element,
-    componentIndex: routerRenderArgs.element.componentIndex - 1,
+    ...component.__internal.element,
+    componentIndex: component.__internal.element.componentIndex - 1,
   };
   rerender(elem);
 }
@@ -38,9 +40,9 @@ export type RouterProps = {
   skipHistoryEventRegistration?: boolean;
 };
 
-let routerRenderArgs: ForgoRenderArgs;
+let component: Component;
 
-export function Router(props: RouterProps) {
+export const Router: ForgoComponentCtor<RouterProps> = (props) => {
   if (!props.skipHistoryEventRegistration) {
     window.addEventListener("popstate", () => {
       updateRoute();
@@ -51,13 +53,13 @@ export function Router(props: RouterProps) {
     });
   }
 
-  return {
-    render(props: RouterProps, args: ForgoRenderArgs) {
-      routerRenderArgs = args;
+  return new Component({
+    render(props, component_) {
+      component = component_;
       return <div>{props.children}</div>;
     },
-  };
-}
+  });
+};
 
 export interface LinkProps
   // We deny the onclick attribute because we set our own click handler and
@@ -69,8 +71,8 @@ export interface LinkProps
   children?: ForgoNode | ForgoNode[];
 }
 
-export function Link(_props: LinkProps) {
-  return {
+export const Link: ForgoComponentCtor<LinkProps> = () => {
+  return new Component({
     render({ children, ...props }: LinkProps) {
       return (
         <a {...props} onclick={createClickHandler(props.href)}>
@@ -78,8 +80,8 @@ export function Link(_props: LinkProps) {
         </a>
       );
     },
-  };
-}
+  });
+};
 
 /*
   Useful for navigating to a url when a link or a button is clicked.


### PR DESCRIPTION
This updates forgo-state for the new component API. It wraps incoming legacy components, so it shouldn't be a breaking change (aside from now depending on forgo@3.2.0-beta.0 and higher). Not sure if that's enough to do a major version bump, your call.